### PR TITLE
Add provision to set the correct locale to environment vars

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -38,4 +38,8 @@ Vagrant.configure("2") do |config|
   config.vm.provision "shell", inline: "git clone https://github.com/firehol/netdata.git --depth=1"
   config.vm.provision "shell", inline: 'cd netdata && echo -e "\n" | sudo ./netdata-installer.sh'
   config.vm.provision "shell", inline: "rm -rf /home/vagrant/netdata"
+
+  # set the locale to environment vars needed by perl
+  config.vm.provision "shell", inline: "echo 'LANGUAGE=en_US.UTF-8' | sudo tee -a /etc/environment"
+  config.vm.provision "shell", inline: "echo 'LC_ALL=en_US.UTF-8' | sudo tee -a /etc/environment"
 end


### PR DESCRIPTION
Without this value set to `LANGUAGE` and `LC_ALL`, this warning appear:

```
WARNING! Your environment specifies an invalid locale.
 The unknown environment variables are:
   LC_CTYPE=UTF-8 LC_ALL=
 This can affect your user experience significantly, including the
 ability to manage packages. You may install the locales by running:

   sudo apt-get install language-pack-UTF-8
     or
   sudo locale-gen UTF-8

To see all available language packs, run:
   apt-cache search "^language-pack-[a-z][a-z]$"
To disable this message for all users, run:
   sudo touch /var/lib/cloud/instance/locale-check.skip
```

With `LANGUAGE` and `LC_ALL` sets, the warning will not be displayed.