### PR TITLE
Add public key inside `vagrant.pub` into `authorized_keys` file

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ clone this repo, and declare configrations like following:
 
 ```ruby
 Vagrant.configure("2") do |config|
-  config.vm.box = "AlbanMontaigu/boot2docker"
+  config.vm.box = "joelhandwell/dockerhost"
   config.vm.provider "virtualbox" do |v|
     v.memory = 8192
     v.cpus = 8
@@ -32,7 +32,7 @@ end
 ```create.bat```
 
 ```bat
-docker-machine create --driver generic --generic-ip-address=192.168.99.103 --generic-ssh-user=docker --generic-ssh-key=vagrant.pem default
+docker-machine create --driver generic --generic-ip-address=192.168.99.103 --generic-ssh-user=vagrant --generic-ssh-key=vagrant.pem default
 ```
 
 and run:

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -38,4 +38,7 @@ Vagrant.configure("2") do |config|
   config.vm.provision "shell", inline: "git clone https://github.com/firehol/netdata.git --depth=1"
   config.vm.provision "shell", inline: 'cd netdata && echo -e "\n" | sudo ./netdata-installer.sh'
   config.vm.provision "shell", inline: "rm -rf /home/vagrant/netdata"
+
+  # add vagrant.pub content to authorized_keys
+  config.vm.provision "shell", inline: "echo 'ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA6NF8iallvQVp22WDkTkyrtvp9eWW6A8YVr+kz4TjGYe7gHzIw+niNltGEFHzD8+v1I2YJ6oXevct1YeS0o9HZyN1Q9qgCgzUFtdOKLv6IedplqoPkcmF0aYet2PkEDo3MlTBckFXPITAMzF8dJSIFo9D8HfdOV0IAdx4O7PtixWKn5y2hMNG0zQPyUecp4pzC6kivAIhyfHilFR61RGL+GPXQ2MWZWFYbAGjyiYJnAmCP3NOTd0jMZEnDkbUvxhMmBYSdETk1rRgm+R4LOzFUGaHqHDLKLX+FIPKcF96hrucXzcWyLbIbEgE98OHlnVYCzRdK8jlqm8tehUc9c9WhQ== vagrant insecure public key' >> /home/vagrant/.ssh/authorized_keys"
 end

--- a/create.bat
+++ b/create.bat
@@ -1,1 +1,1 @@
-docker-machine create --driver generic --generic-ip-address=192.168.2.193 --generic-ssh-user=docker --generic-ssh-key ./vagrant default
+docker-machine create --driver generic --generic-ip-address=192.168.2.193 --generic-ssh-user=vagrant --generic-ssh-key ./vagrant default


### PR DESCRIPTION
Now this vagrant box using ubuntu instead of boot2docker, the command to create generic docker-machine need to be updated.

I add provisioning script to add the content of `vagrant.pub` into `authorized_keys` file. I also update the `create.bat` to use user `vagrant`.